### PR TITLE
[음정민] Fix: return category name

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -16,6 +16,7 @@ class ProductListView(View):
 
         category_data = {
             'id'            : category.id,
+            'name'          : category.name,
             'description'   : category.description,
             'total_products': products.count()
             }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 리턴해주는 데이터에 카테고리 이름이 누락돼서 추가했습니다

<br />

## :: 기타 질문 및 특이 사항
- url이 /products/\<int:category_id\>일때 products.ProductListView로 가고 ProductListView에서 def get(self, request, category_id=1000): 이렇게 받고 있어서 /product까지만 보내면 기본값으로 category_id에 1000이 할당돼서 1000번 카테고리 (전체목록)보여주는 걸로 생각했는데 /products까지만 보내니까 기본값이 none일때랑 다르게 /products를 못찾더라구요(Not Found: /products/) /products 까지만 요청이 왔을때도 전체상품목록이 보이도록 하려면 어떻게 해야하나요?빈 엔드포인트도 path에 추가를 해서 ProductListView로 똑같이 연결되도록 하면 될까요?
