### PR TITLE
[음정민] 상품-옵션아이디 중복리스트 제거

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -96,11 +96,11 @@ class ProductDetailView(View):
                 'options' : [{
                     'option_id'           : option.id,
                     'name'                : option.name,
-                    'product_option_id'   : product.productoption_set.get(product_id=product.id, option_id=option.id).id,
-                    'product_option_stock': product.productoption_set.get(product_id=product.id, option_id=option.id).stock
+                    'product_option_id'   : product.productoption_set.get(option_id=option.id).id,
+                    'product_option_stock': product.productoption_set.get(option_id=option.id).stock
                     } for option in options]
             }
-            
+
             return JsonResponse({'result': result}, status=200)
             
         except Product.DoesNotExist:

--- a/products/views.py
+++ b/products/views.py
@@ -94,14 +94,13 @@ class ProductDetailView(View):
                     'url': image.url
                     } for image in images],
                 'options' : [{
-                    'option_id'                 : option.id,
-                    'name'                      : option.name,
-                    'product_option_information': [{
-                        'product_option_id'   : product_option.id,
-                        'product_option_stock': product_option.stock
-                        } for product_option in product.productoption_set.all()],
+                    'option_id'           : option.id,
+                    'name'                : option.name,
+                    'product_option_id'   : product.productoption_set.get(product_id=product.id, option_id=option.id).id,
+                    'product_option_stock': product.productoption_set.get(product_id=product.id, option_id=option.id).stock
                     } for option in options]
             }
+            
             return JsonResponse({'result': result}, status=200)
             
         except Product.DoesNotExist:


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 중복되는 상품-옵션정보 리스트 제거

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 상품상세정보에서 각 옵션마다 모든 상품-옵션 정보가 들어가서 해당 옵션 정보만 나오게 변경
- 상품1의 옵션(10,20)가 있을때 각 상품-옵션id가(100,200)이면
- 상품1-(옵션10-상품옵션100, 옵션20-상품옵션200) 이렇게  나와야 하는데
- 상품1-(옵션10-(상품옵션100, 상품옵션200)), 상품1-(옵션20-(상품옵션100, 상품옵션200))
- 이렇게 나와서 변경했습니다


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 상품1번의 옵션이 하나밖에 없어서 수정전 코드에서 상품-옵션정보가 하나씩만 나왔는데 상품1만 테스트해보고 정상작동인줄 알고 올렸습니다. 테스트를 제대로 해보겠습니다!

<br />

## :: 기타 질문 및 특이 사항
- 없음
