### PR TITLE
[음정민] 메인페이지 orm 최적화

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -20,9 +20,9 @@ class MainPageView(View):
             
             return product_list
 
-        new_products   = Product.objects.all().order_by('-created_at')[:8]
-        best_products  = Product.objects.filter(is_best = True).order_by('-created_at')[:8] 
-        green_products = Product.objects.filter(is_green = True).order_by('-created_at')[:8]
+        new_products   = Product.objects.all().prefetch_related('productimage_set').order_by('-created_at')[:8]
+        best_products  = Product.objects.filter(is_best = True).prefetch_related('productimage_set').order_by('-created_at')[:8] 
+        green_products = Product.objects.filter(is_green = True).prefetch_related('productimage_set').order_by('-created_at')[:8]
 
         return JsonResponse({
             'new_products'  : get_list(new_products),


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 메인페이지 요청시 호출되는 쿼리 수를 줄였다

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. prefetch_related를 이용해서 쿼리수를 27->6개로 줄였습니다.


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 전체 테이블을 그냥 불러오는건 db를 hit하지 않지만 전체테이블을 정렬하는건 db를 hit하고 select_related나 prefetch_related를 사용해서 orm최적화를 할 수 있다.

<br />

## :: 기타 질문 및 특이 사항
- 없음
